### PR TITLE
Refactor amount assignment in partialPayment.ts

### DIFF
--- a/packages/xahau/src/client/partialPayment.ts
+++ b/packages/xahau/src/client/partialPayment.ts
@@ -64,10 +64,8 @@ function isPartialPayment(
   }
 
   const delivered = meta.delivered_amount
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- DeliverMax is a valid field on Payment response
-  // @ts-expect-error -- DeliverMax is a valid field on Payment response
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- DeliverMax is a valid field on Payment response
-  const amount = tx.DeliverMax
+
+  const amount = tx.DeliverMax ?? tx.Amount
 
   if (delivered === undefined) {
     return false

--- a/packages/xahau/src/client/partialPayment.ts
+++ b/packages/xahau/src/client/partialPayment.ts
@@ -65,6 +65,9 @@ function isPartialPayment(
 
   const delivered = meta.delivered_amount
 
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- DeliverMax is a valid field on Payment response
+  // @ts-expect-error -- DeliverMax is a valid field on Payment response
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- DeliverMax is a valid field on Payment response
   const amount = tx.DeliverMax ?? tx.Amount
 
   if (delivered === undefined) {


### PR DESCRIPTION
`DeliverMax` is expected from xahau.js but it should fallback to Amount.

`DeliverMax` is returned in xrpl API v2, but `Amount` is used when querying via API v1 which is xahau at at the moment.

This should be handled in any case, fix taken from xrpl.js here:

https://github.com/XRPLF/xrpl.js/blob/29108b373e795c697dd99274f6794a9fbf2f85f7/packages/xrpl/src/client/partialPayment.ts#L101

Reproducable on:
Xahau testnet transaction C0710F260000535A

## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users

